### PR TITLE
feat(ui): implement land and apartment listing screens

### DIFF
--- a/lib/ui/category/apartment.dart
+++ b/lib/ui/category/apartment.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:get/get_core/src/get_main.dart';
+import 'package:get/get_navigation/get_navigation.dart';
+import 'package:hearth/utils/colors.dart';
+import 'package:hearth/utils/text_style.dart';
+
+class ApartmentScreen extends StatefulWidget {
+  ApartmentScreen({super.key});
+
+  @override
+  State<ApartmentScreen> createState() => _ApartmentScreenState();
+}
+
+class _ApartmentScreenState extends State<ApartmentScreen> {
+  final List<Map<String, dynamic>> properties = [
+    {
+      "title": "1 Bedroom Apartment",
+      "price": "₦120,700 /night",
+      "location": "GRA, Port Harcourt",
+       "image": "assets/images/bedroom_two.jpg"
+    },
+    {
+      "title": "2 Bedroom Apartment ",
+      "price": "₦75,000 /night",
+      "location": "Woji, Port Harcourt",
+      "image": "assets/images/sittingroom_six.jpg"
+    },
+    {
+      "title": "1 Bedroom Apartment ",
+      "price": "₦200,000 /night",
+      "location": "Lekki, Lagos",
+      "image": "assets/images/sittingroom_seven.jpg"
+    },
+    {
+      "title": "1 Bedroom Apartment",
+      "price": "₦270,000 /night",
+      "location": "Harmony Estate,Port Harcourt,Rivers State",
+      "image": "assets/images/sittingroom_eight.jpg"
+    },
+    {
+      "title": "2 Bedroom Apartment",
+      "price": "₦150,000 /night",
+      "location": "Ikokwu, Port Harcourt, Rivers State",
+      "image": "assets/images/sittingroom_three.jpg"
+    },
+    {
+      "title": "1 Bedroom Apartment",
+      "price": "₦100,000 /night",
+      "location": "Asaba, Delta State",
+      "image": "assets/images/sittingroom_five.jpg"
+    },
+    
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text("Apartment",style: Body2Text),
+        centerTitle: true,
+        backgroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: Padding(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: 16),
+            Text("${properties.length} results",style: Body10Text ),
+            SizedBox(height: 16),
+            Expanded(
+              child: ListView.separated(
+                itemCount: properties.length,
+                separatorBuilder: (_, __) => SizedBox(height: 16),
+                itemBuilder: (context, index) {
+                  final property = properties[index];
+                  return InkWell(
+                    onTap:(){
+                    //  Get.to(()=>PropertyDetailScreen(property:property));
+                    },
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: inputGrey,
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(color: Color(0xfff7f6f6)),
+                      ),
+                      child: Row(
+                        children: [
+                          Padding(padding: EdgeInsetsGeometry.all(8)),
+                          ClipRRect(
+                            borderRadius: BorderRadius.all(Radius.circular(7)),
+                            child: Image.network(
+                              property["image"],
+                              height: 72,
+                              width: 97,
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                          SizedBox(width: 12),
+                          Expanded(
+                            child: Padding(
+                              padding: EdgeInsets.symmetric(vertical: 13),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    property["title"],
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TitleText
+                                  ),
+                                  SizedBox(height: 8),
+                                  Text(property["price"],style: Body5Text,
+                                  ),
+                                  SizedBox(height: 8),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    children: [
+                                      Icon(Icons.location_on_outlined,color: locationBlack,),
+                                      SizedBox(width: 3),
+                                      Text(
+                                        property["location"],
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: TextStyle(fontSize: 12,color: darkGrey,),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          )
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/category/land.dart
+++ b/lib/ui/category/land.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:get/get_core/src/get_main.dart';
+import 'package:get/get_navigation/get_navigation.dart';
+import 'package:hearth/utils/colors.dart';
+import 'package:hearth/utils/text_style.dart';
+
+class LandScreen extends StatefulWidget {
+  LandScreen({super.key});
+
+  @override
+  State<LandScreen> createState() => _LandScreenState();
+}
+
+class _LandScreenState extends State<LandScreen> {
+  final List<Map<String, dynamic>> properties = [
+    {
+      "title": "Open lands for sale",
+      "price": "₦23,500,700 /plot",
+      "location": "Apo, Abuja",
+       "image": "assets/images/land_one.jpg"
+    },
+    {
+      "title": "Open lands for sale",
+      "price": "₦3,750,000 /plot",
+      "location": "Igwurutali, Rivers State",
+      "image": "assets/images/land_two.jpg"
+    },
+    {
+      "title": "Open lands for sale ",
+      "price": "₦72,750,000 /plot",
+      "location": "Asokoro, Abuja",
+      "image": "assets/images/land_three.jpg"
+    },
+    {
+      "title": "Open lands for sale",
+      "price": "₦23,270,000 /plot",
+      "location": "Harmony Estate,Port Harcourt,Rivers State",
+      "image": "assets/images/land_four.jpg"
+    },
+    {
+      "title": "Open lands for sale",
+      "price": "₦5,000,000 /plot",
+      "location": "Ikokwu, Port Harcourt, Rivers State",
+      "image": "assets/images/land_one.jpg"
+    },
+    {
+      "title": "Open lands for sale",
+      "price": "₦23,350,000 /plot",
+      "location": "Asaba, Delta State",
+      "image": "assets/images/land_two.jpg"
+    },
+    
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: Colors.black),
+          onPressed: () => Navigator.pop(context),
+        ),
+        title: Text("Land",style: Body2Text),
+        centerTitle: true,
+        backgroundColor: Colors.white,
+        elevation: 0,
+      ),
+      body: Padding(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            SizedBox(height: 16),
+            Text("${properties.length} results",style: Body10Text ),
+            SizedBox(height: 16),
+            Expanded(
+              child: ListView.separated(
+                itemCount: properties.length,
+                separatorBuilder: (_, __) => SizedBox(height: 16),
+                itemBuilder: (context, index) {
+                  final property = properties[index];
+                  return InkWell(
+                    onTap:(){
+                    //  Get.to(()=>PropertyDetailScreen(property:property));
+                    },
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: inputGrey,
+                        borderRadius: BorderRadius.circular(8),
+                        border: Border.all(color: Color(0xfff7f6f6)),
+                      ),
+                      child: Row(
+                        children: [
+                          Padding(padding: EdgeInsetsGeometry.all(8)),
+                          ClipRRect(
+                            borderRadius: BorderRadius.all(Radius.circular(7)),
+                            child: Image.network(
+                              property["image"],
+                              height: 72,
+                              width: 97,
+                              fit: BoxFit.cover,
+                            ),
+                          ),
+                          SizedBox(width: 12),
+                          Expanded(
+                            child: Padding(
+                              padding: EdgeInsets.symmetric(vertical: 13),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    property["title"],
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TitleText
+                                  ),
+                                  SizedBox(height: 8),
+                                  Text(property["price"],style: Body5Text,
+                                  ),
+                                  SizedBox(height: 8),
+                                  Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    children: [
+                                      Icon(Icons.location_on_outlined,color: locationBlack,),
+                                      SizedBox(width: 3),
+                                      Text(
+                                        property["location"],
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: TextStyle(fontSize: 12,color: darkGrey,),
+                                      ),
+                                    ],
+                                  ),
+                                ],
+                              ),
+                            ),
+                          )
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get_core/src/get_main.dart';
 import 'package:get/get_navigation/get_navigation.dart';
 import 'package:hearth/ui/category/Lease.dart';
+import 'package:hearth/ui/category/land.dart';
 import 'package:hearth/ui/category/rental.dart';
 import 'package:hearth/utils/colors.dart' as AppColors;
 import 'package:hearth/utils/colors.dart';
@@ -118,7 +119,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
                 GestureDetector(
                   onTap: (){
-                    Get.to(()=>());
+                    Get.to(()=>LandScreen());
                   },
                   child: CategoryButton(icon: Icons.landscape, label: "Land"),
                 ),

--- a/lib/ui/home/home.dart
+++ b/lib/ui/home/home.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get_core/src/get_main.dart';
 import 'package:get/get_navigation/get_navigation.dart';
 import 'package:hearth/ui/category/Lease.dart';
+import 'package:hearth/ui/category/apartment.dart';
 import 'package:hearth/ui/category/land.dart';
 import 'package:hearth/ui/category/rental.dart';
 import 'package:hearth/utils/colors.dart' as AppColors;
@@ -125,7 +126,7 @@ class _HomeScreenState extends State<HomeScreen> {
                 ),
                 GestureDetector(
                   onTap: (){
-                    Get.to(()=>());
+                    Get.to(()=>ApartmentScreen());
                   },
                   child: CategoryButton(icon: Icons.business, label: "Commercial"),
                 ),


### PR DESCRIPTION
Implemented LandScreen and ApartmentScreen to display property listings.

Added reusable PropertyCard widget for land and apartment containers.

The design for Land screen:
<img width="430" height="932" alt="Frame 1000006196" src="https://github.com/user-attachments/assets/53966115-2514-4e9b-8a10-3c0f57e1ed18" />

My code output:

<img width="409" height="756" alt="Screenshot (964)" src="https://github.com/user-attachments/assets/fd79776f-c18f-48b4-98d7-61b3fe433942" />

The design for Apartment screen:
<img width="430" height="932" alt="Frame 1171275543" src="https://github.com/user-attachments/assets/a45c2a61-523e-4ac5-8158-6022a29b49f5" />

My code output:
<img width="416" height="761" alt="Screenshot (963)" src="https://github.com/user-attachments/assets/1409c36d-0986-4fe5-a641-ea7292b11d9e" />
